### PR TITLE
Efficiently read safetensors from disk

### DIFF
--- a/lib/safetensors.ex
+++ b/lib/safetensors.ex
@@ -91,7 +91,7 @@ defmodule Safetensors do
   Tensors are loaded into Nx one by one,
   without loading the whole file into disk.
   """
-  @spec read!(path :: iodata()) :: %{String.t() => Nx.Tensor.t()}
+  @spec read!(path :: Path.t()) :: %{String.t() => Nx.Tensor.t()}
   def read!(path) do
     File.open!(path, [:read, :raw], fn file ->
       {:ok, <<header_size::unsigned-64-integer-little>>} = :file.read(file, 8)

--- a/test/safetensors_test.exs
+++ b/test/safetensors_test.exs
@@ -16,6 +16,20 @@ defmodule SafetensorsTest do
              ~s(<\x00\x00\x00\x00\x00\x00\x00{"test":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]}}\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00)
   end
 
+  @tag :tmp_dir
+  test "read", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "safetensor")
+
+    # source:
+    # https://github.com/huggingface/safetensors/blob/1a65a3fdebcf280ef0ca32934901d3e2ad3b2c65/bindings/python/tests/test_simple.py#L35-L40
+    File.write!(
+      path,
+      ~s(<\x00\x00\x00\x00\x00\x00\x00{"test":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]}}\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00)
+    )
+
+    assert Safetensors.read!(path) == %{"test" => Nx.tensor([[0, 0], [0, 0]], type: :s32)}
+  end
+
   test "load" do
     # source:
     # https://github.com/huggingface/safetensors/blob/1a65a3fdebcf280ef0ca32934901d3e2ad3b2c65/bindings/python/tests/test_simple.py#L35-L40


### PR DESCRIPTION
@jonatanklosko if you agree with the direction, it may be a good idea to use safetensor as the default way of loading models for Bumblebee. It puts lets pressure on memory.