### PR TITLE
feat: don't force user to jason dependency if Elixir JSON available

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,8 +24,12 @@ defmodule Safetensors.MixProject do
 
   defp deps do
     [
-      {:jason, "~> 1.4"},
       {:nx, "~> 0.5"},
+
+      # Optional
+      {:jason, "~> 1.4", optional: true},
+
+      # Dev
       {:ex_doc, "~> 0.37", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
Exploring no longer imposing the `jason` dependency.

Seems it would break the ordered header keys.